### PR TITLE
pytorch callbacks

### DIFF
--- a/crop_health_model/configs/config.yaml
+++ b/crop_health_model/configs/config.yaml
@@ -41,6 +41,17 @@ fit:
     devices: 
     - 0
     - 1
+    callbacks:
+    - class_path: lightning.pytorch.callbacks.EarlyStopping
+      init_args:
+        monitor: "val_loss"
+        mode: "min"
+    - class_path: lightning.pytorch.callbacks.ModelCheckpoint
+      init_args:
+        monitor: "val_loss"
+        mode: "min"
+        save_top_k: 1
+        filename: "crop_health_model-{epoch}-{step}-{val_loss:.3f}"
   optimizer:
     class_path: torch.optim.Adam
     init_args:


### PR DESCRIPTION
Adds two PyTorch callbacks, one for early stopping based on the validation loss, the other for specifying when to save model checkpoints (only when val loss decreases)