### PR TITLE
save model hyperparams

### DIFF
--- a/crop_health_model/engines/system.py
+++ b/crop_health_model/engines/system.py
@@ -13,6 +13,8 @@ class LitModel(pl.LightningModule):
     ) -> None:
         super(LitModel, self).__init__()
         self.model = model
+        hyperparameters = self.model.get_hyperparameters()
+        self.save_hyperparameters(hyperparameters)
 
     def forward(self, x) -> torch.Tensor:
         return self.model(x)

--- a/crop_health_model/models/model.py
+++ b/crop_health_model/models/model.py
@@ -42,3 +42,10 @@ class ResNet(nn.Module):
     def forward(self, x: torch.Tensor) -> torch.Tensor:
         """Forward pass of the model."""
         return self.resnet(x)
+
+    def get_hyperparameters(self) -> dict:
+        """Return the hyperparameters of the model."""
+        return {
+            "num_classes": self.num_classes,
+            "num_layers": self.num_layers,
+        }


### PR DESCRIPTION
Saves hyperparameters using the `LightningModule`'s `self.save_hyperparameters()`