### PR TITLE
Feat/torchserve callbacks

### DIFF
--- a/crop_health_model/configs/config.yaml
+++ b/crop_health_model/configs/config.yaml
@@ -57,15 +57,6 @@ fit:
     - class_path: crop_health_model.engines.callbacks.SaveSimplifiedCheckpoint
       init_args:
         filename: "best_model"
-    logger: 
-    - class_path: lightning.pytorch.loggers.TensorBoardLogger
-      init_args:
-        save_dir: "tb_logs"
-        name: "multi_HLT"
-    - class_path: lightning.pytorch.loggers.CSVLogger
-      init_args:
-        save_dir: "csv_logs"
-        name: "multi_HLT"
   optimizer:
     class_path: torch.optim.Adam
     init_args:

--- a/crop_health_model/configs/config.yaml
+++ b/crop_health_model/configs/config.yaml
@@ -42,7 +42,7 @@ fit:
     - 0
     - 1
     callbacks:
-    - class_path: crop_health_model.engines.callbacks.SaveDictionaryCallback
+    - class_path: crop_health_model.engines.callbacks.SaveDataDictionaryCallback
       init_args:
         dict_name: "class_map"
         filename: "index_to_name"

--- a/crop_health_model/configs/config.yaml
+++ b/crop_health_model/configs/config.yaml
@@ -41,6 +41,31 @@ fit:
     devices: 
     - 0
     - 1
+    callbacks:
+    - class_path: crop_health_model.engines.callbacks.SaveDictionaryCallback
+      init_args:
+        dict_name: "class_map"
+        filename: "index_to_name"
+    - class_path: crop_health_model.engines.callbacks.SaveModelScriptCallback
+      init_args:
+        filename: "model_script.py"
+        template_path: "crop_health_model/models/model.py"
+    - class_path: crop_health_model.engines.callbacks.SaveModelHandlerCallback
+      init_args:
+        filename: "model_handler.py"
+        config_path: "crop_health_model/configs/config.yaml"
+    - class_path: crop_health_model.engines.callbacks.SaveSimplifiedCheckpoint
+      init_args:
+        filename: "best_model"
+    logger: 
+    - class_path: lightning.pytorch.loggers.TensorBoardLogger
+      init_args:
+        save_dir: "tb_logs"
+        name: "multi_HLT"
+    - class_path: lightning.pytorch.loggers.CSVLogger
+      init_args:
+        save_dir: "csv_logs"
+        name: "multi_HLT"
   optimizer:
     class_path: torch.optim.Adam
     init_args:

--- a/crop_health_model/engines/callbacks.py
+++ b/crop_health_model/engines/callbacks.py
@@ -7,7 +7,7 @@ import yaml
 from lightning.pytorch.callbacks import Callback
 
 
-class SaveDictionaryCallback(Callback):
+class SaveDataDictionaryCallback(Callback):
     """Callback to save a dictionary from the LightningDataModule as a JSON file."""
 
     def __init__(self, dict_name: str, filename: str) -> None:

--- a/crop_health_model/engines/callbacks.py
+++ b/crop_health_model/engines/callbacks.py
@@ -1,0 +1,182 @@
+import json
+import os
+
+import lightning.pytorch as pl
+import torch
+import yaml
+from lightning.pytorch.callbacks import Callback
+
+
+class SaveDictionaryCallback(Callback):
+    """Callback to save a dictionary from the LightningDataModule as a JSON file."""
+
+    def __init__(self, dict_name: str, filename: str) -> None:
+        """
+        Args:
+            dict_name (str): Attribute name of the dictionary in the LightningDataModule.
+            filename (str): Filename to save the dictionary as.
+        """
+        self.dict_name = dict_name
+        self.filename = filename
+
+    def on_train_start(
+        self, trainer: pl.Trainer, pl_module: pl.LightningModule
+    ) -> None:
+        """Called when the training starts."""
+
+        # Access the dictionary from the LightningDataModule
+        dataset = trainer.datamodule.data
+        dict_to_save = getattr(dataset, self.dict_name, None)
+
+        if dict_to_save is not None:
+            # Invert the dictionary
+            dict_to_save = {value: key for key, value in dict_to_save.items()}
+            # Build the path using trainer's log_dir
+            filepath = os.path.join(trainer.log_dir, self.filename)
+            # save as JSON file
+            with open(filepath + ".json", "w") as f:
+                json.dump(dict_to_save, f)
+
+
+class SaveModelScriptCallback(Callback):
+    """Callback to save the model script with updated hyperparameters.
+
+    This callback is useful when you want to save the model script with the hyperparameters used for training.
+    Then, the script can be used with torch-model-archiver to easily create a TorchServe model archive.
+    """
+
+    def __init__(self, filename: str, template_path: str) -> None:
+        """
+        Args:
+            filepath (str): Path to save the updated model script.
+            template_path (str): Path to the model template script.
+        """
+        self.filename = filename
+        self.template_path = template_path
+
+    def on_train_start(
+        self, trainer: pl.Trainer, pl_module: pl.LightningModule
+    ) -> None:
+        """Called when the train starts."""
+        # Get the hyperparameters from the model
+        hyperparameters = pl_module.model.get_hyperparameters()
+        filepath = os.path.join(trainer.log_dir, self.filename)
+
+        # Save the model script based on hyperparameters
+        self.save_model_script(hyperparameters, filepath)
+
+    def save_model_script(self, hyperparameters: dict, filepath: str) -> None:
+        """Saves the model script based on the provided hyperparameters."""
+        with open(self.template_path, "r", encoding="utf-8") as file:
+            content = file.read()
+
+        for key, value in hyperparameters.items():
+            # This assumes `key` directly matches the string in the template.
+            content = content.replace(
+                f"{key}: {type(value).__name__}",
+                f"{key}: {type(value).__name__} = {value}",
+                1,  # Replace only the first occurrence
+            )
+
+        # Write the updated content back to the specified filepath
+        with open(filepath, "w", encoding="utf-8") as file:
+            file.write(content)
+
+        print(f"Updated model script saved to {filepath}")
+
+
+class SaveModelHandlerCallback(Callback):
+    """Callback to generate a handler script when training starts.
+
+    This callback is useful when you want to generate a handler script for TorchServe when training starts.
+    The handler only defines the image transform pipeline based on the configuration file.
+    """
+
+    def __init__(self, filename: str, config_path: str) -> None:
+        """
+        Args:
+            filename (str): The filename to save the generated handler script.
+            config_path (str): The path to the YAML configuration file.
+        """
+        self.filename = filename
+        self.config_path = config_path
+
+    def on_train_start(
+        self, trainer: pl.Trainer, pl_module: pl.LightningModule
+    ) -> None:
+        """Called when the train starts to generate the handler script."""
+
+        # Generate the handler script
+        filepath = os.path.join(trainer.log_dir, self.filename)
+        self.generate_handler_script(filepath)
+
+    def generate_handler_script(self, filepath: str) -> None:
+        """Reads the YAML config and generates a handler script."""
+        with open(self.config_path, "r") as file:
+            config = yaml.safe_load(file)
+
+        test_transforms = config["fit"]["data"].get("test_transforms", [])
+        normalization = config["fit"]["data"].get("normalization", None)
+
+        transform_lines = [
+            f"        {self.get_transform_code(transform)},"
+            for transform in test_transforms
+        ]
+        transform_lines.append("        transforms.ToTensor(),")
+        if normalization is not None:
+            transform_lines.append(f"        {self.get_transform_code(normalization)},")
+
+        transform_pipeline_code = "\n".join(transform_lines)
+
+        handler_script = f"""
+from torchvision import transforms
+from ts.torch_handler.image_classifier import ImageClassifier
+
+class CustomHandler(ImageClassifier):
+    image_processing = transforms.Compose([
+{transform_pipeline_code}
+    ])
+"""
+        with open(filepath, "w") as f:
+            f.write(handler_script)
+        print(f"Handler script saved to {filepath}")
+
+    def get_transform_code(self, transform: dict) -> str:
+        """Generates the Python code for a transform."""
+        class_path = transform["class_path"].split(".")[-1]
+        init_args = ", ".join(f"{k}={v}" for k, v in transform["init_args"].items())
+        return f"transforms.{class_path}({init_args})"
+
+
+class SaveSimplifiedCheckpoint(Callback):
+    """Callback to save a simplified checkpoint with only the model's state_dict."""
+
+    def __init__(self, filename) -> None:
+        """
+        Args:
+            save_path (str): Directory where the simplified checkpoints will be saved.
+        """
+        self.filename = filename
+
+    def on_save_checkpoint(
+        self, trainer: pl.Trainer, pl_module: pl.LightningModule, checkpoint: dict
+    ) -> None:
+        """Called when saving a checkpoint."""
+        # Extract the state_dict from the checkpoint
+        state_dict = checkpoint["state_dict"]
+
+        # remove "model." prefix from the keys because the underlying PyTorch model
+        # is wrapped by the LightningModule
+        state_dict = {k.replace("model.", ""): v for k, v in state_dict.items()}
+
+        # define the directory and create it if it doesn't exist
+        dir_path = f"{trainer.logger.log_dir}/checkpoints"
+        os.makedirs(dir_path, exist_ok=True)
+
+        # Define the path for the simplified checkpoint
+        file_path = f"{dir_path}/{self.filename}.pt"
+
+        # Save only the state_dict to a new checkpoint file
+        torch.save(state_dict, file_path)
+
+        print(f"Simplified checkpoint saved to: {file_path}")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,8 @@ torch = "^2.2.1"
 torchvision = "^0.17.1"
 lightning = "^2.2.1"
 pandas = "^2.2.1"
-
+pyyaml = "^6.0.1"
+torch-model-archiver = "^0.10.0"
 
 [tool.poetry.group.dev.dependencies]
 black = "^24.2.0"


### PR DESCRIPTION
Adds functionality for four callbacks that generate artifacts that are useful for generating the model archive file (MAR) using `torch-model-archiver`.
The first three callbacks all run once at the start of training (using `on_train_start()`):
- `SaveDataDictionaryCallback` saves the class map dictionary (index to name) of the underlying `Dataset` of the `LightningDataModule` as a JSON file. This JSON file is passed as an optional parameter to `torch-model-archiver`, so that predictions produced by TorchServe use the class name instead of some class index.
- `SaveModelScriptCallback` saves the script defining the PyTorch model (not the `LightningModule` that wraps around it) and sets the default model hyperparameters to the actual values used during training. This is done because `torch-model-archiver` requires the script where the model is defined in order to produce the MAR file, and TorchServe, by default, simply instantiates the model inside its handler's `initialization()` method as: `model = Model()`. Another solution is to override the `initialization()` method and specify hyperparameters during model instantiation, but it is already quite big and complex so it seemed like a bad tradeoff. 
- `SaveModelHandlerCallback` saves the model handler which is required by `torch-model-archiver`. The callback uses a preexisting `ImageClassifier` handler defined by TorchServe, and simply overrides the transformation to apply to the images before feeding them to the model.
- `SaveSimplifiedCheckpoint` saves the state dictionary of the model as a ".pth" file. The callback accesses the `checkpoint` dict every time a new checkpoint is saved (using `on_save_checkpoint()`)