### PR TITLE
fix: use correct image name in deployment

### DIFF
--- a/deployment/kubernetes/crop-health-api.yaml
+++ b/deployment/kubernetes/crop-health-api.yaml
@@ -18,7 +18,7 @@ spec:
         prometheus.io/path: "/metrics"
     spec:
       containers:
-        - image: ghcr.io/openearthplatforminitiative/crop-health-api:0.0.1
+        - image: ghcr.io/openearthplatforminitiative/crop-health-model:0.0.1
           name: crop-health-api
           ports:
             - containerPort: 8080  # Inference API


### PR DESCRIPTION
CD-pipeline use the name of the repository as the name of the image. If you want to change the name of the image, you will have to either change the name of the repository, or change the CD-pipeline